### PR TITLE
Feature/dynamic build image names

### DIFF
--- a/internal/build/reproducible.go
+++ b/internal/build/reproducible.go
@@ -59,6 +59,11 @@ func Create(imageTag string, dockerFilePath string) error {
 }
 
 func Export(image string, hostPath string, out string) error {
+	if filepath.Dir(out) == "." {
+		fmt.Println("out", out)
+		out = filepath.Dir(out)
+	}
+
 	cpCmd := exec.Command("bash", "-c", fmt.Sprintf("docker run -v %s:/opt/out -i %s cp -R %s /opt/out", hostPath, image, out))
 	cpCmd.Stdout = os.Stdout
 	cpCmd.Stderr = os.Stderr

--- a/internal/build/testdata/goTestProject/valist.yml
+++ b/internal/build/testdata/goTestProject/valist.yml
@@ -1,3 +1,7 @@
+org: goTest
+repo: goExample
+tag: 0.0.1
+
 # The project type
 type: go
 

--- a/internal/build/testdata/npmTestProject/valist.yml
+++ b/internal/build/testdata/npmTestProject/valist.yml
@@ -1,3 +1,6 @@
+org: npmTest
+repo: npmExample
+tag: 0.0.1
 type: npm
 install: npm install
 build: npm run build


### PR DESCRIPTION
Refactors build.Run() to use Org, Repo, and Tag when calling build.Create() and build.Export().
Adds a small out directory bug fix for single artifact builds.